### PR TITLE
Added support for multiple -r flags

### DIFF
--- a/src/tslint-cli.ts
+++ b/src/tslint-cli.ts
@@ -199,7 +199,11 @@ const processFile = (file: string) => {
     const rulesDirectories = getRulesDirectories(configuration.rulesDirectory, configurationDir);
 
     if (argv.r != null) {
-        rulesDirectories.push(argv.r);
+        if (Array.isArray(argv.r)){
+            rulesDirectories.push(argv.r);
+        } else {
+            rulesDirectories.push(argv.r);
+        }
     }
 
     const linter = new Linter(file, contents, {


### PR DESCRIPTION
When using multiple -r flags, optimist creates an array. This array should be rather be concated to the `rulesDirectories`.
